### PR TITLE
feat: logback-spring.xml 설정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
+
+    <!--Console appender-->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="com.cheocharm.MapZ" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="prod">
+        <logger name="com.cheocharm.MapZ" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+</configuration>
+


### PR DESCRIPTION
logback-spring.xml 설정했습니다 ~

스프링을 쓸 경우 logback.xml
스프링부트의 경우 logback-spring.xml을 사용한다고 하네요

logback.xml으로 작성하면 spring boot가 시작되기 전에 읽어오기 때문에
spring이 제공해주는 프로파일 확장 기능을 사용하고 스프링 설정 값을 가져오려면
logback-spring.xml으로 작성하라고 권장한다고 합니다!

두 번째 줄에 configuration scan은 xml 파일이 바뀌면 자동으로 스캔해줍니다
default는 1분에 한 번씩 스캔! 보통 30초 ~ 1분으로 설정합니다

local은 DEBUG, prod는 INFO로 로그 단계 설정해놨습니다
나중에 출시하면 로그 파일로 관리하는 것도 좋을 것 같아요 ~

슬랙에 변경된 yml파일을 올려놨으니 바꿔주시고 풀받아주세요
안그러면 오류납니다😶

로그 잘 찍히는지 테스트까지 완료 ~!