### PR TITLE
fix: 배포 스크립트 수정 및 plain.jar 생성제한

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
+tasks.named('jar') {
+	enabled = false
+}
+
 def querydslDir = "$buildDir/generated/querydsl"
 querydsl {
 	jpa = true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,30 +1,24 @@
 #!/usr/bin/env bash
 
-PROFILE = $1
-DOCKER_ID = $2
-DOCKER_PASSWORD = $3
+PROFILE=$1
+DOCKER_ID=$2
+DOCKER_PASSWORD=$3
 
-echo ">>start build project"
-
-sh gradlew clean build
-
-echo ">>project build succeed"
-
-TIMESTAMP = $(date +%s)
+TIMESTAMP=$(date +%s)
 DOCKER_TAG=latest-${PROFILE}-${TIMESTAMP}
-DOCKER_IMAGE=MapZ-${PROFILE}:${DOCKER_TAG}
-
-sudo docker build -t ${DOCKER_IMAGE} --build-arg SPRING_ENV=${PROFILE} --platform linux/amd64 .
-echo ">>docker build succeed"
+DOCKER_IMAGE=mapz/mapz-backend-prod:${DOCKER_TAG}
 
 sudo docker login -u ${DOCKER_ID} -p ${DOCKER_PASSWORD}
 echo ">>docker login succeed"
 
+sudo docker build -t ${DOCKER_IMAGE} --build-arg SPRING_ENV=${PROFILE} --platform linux/amd64 .
+echo ">>docker build succeed"
+
 sudo docker push ${DOCKER_IMAGE}
 echo ">>docker push succeed"
 
-sudo docker stop $(docker ps -a -q)
-sudo docker rm $(docker ps -a -q)
+sudo docker stop $(sudo docker ps -aq)
+sudo docker rm $(sudo docker ps -aq)
 
 sudo docker run -d -p 8080:8080 -e "SPRING_ENV=${PROFILE}" --name=MapZ ${DOCKER_IMAGE}
 


### PR DESCRIPTION
- gradle 수정을 하면 다음과 같이 skip이 되어 plain.jar을 생성하지 않게 됩니다.
![image](https://user-images.githubusercontent.com/83572469/176991285-fdbfee25-d57c-49bd-bbde-c297d8b130b9.png)

- ec2에서 빌드 시 시간과 점유율 문제로 빌드는 각자가 하고 직접 Jar 파일을 올리도록 스크립트를 변경했습니다.
- 그외 배포가 정상적으로 진행되기 위한 스크립트 수정들이 있었습니다.

