### PR TITLE
feat: 그룹 공개여부 변경 API 추가

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
@@ -23,7 +23,9 @@ public enum ExceptionDetails {
     DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "2004", "중복된 닉네임입니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "2005", "가입된 사용자가 아닙니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "2006", "비밀번호가 일치하지 않습니다."),
-    INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "2007", "유효성 검사 통과에 실패하였습니다");
+    INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "2007", "유효성 검사 통과에 실패하였습니다"),
+    NOT_FOUND_GROUP(HttpStatus.NOT_FOUND, "2008", "해당되는 그룹이 없습니다."),
+    NO_PERMISSION_USER(HttpStatus.BAD_REQUEST, "2009", "허가되지 않은 유저입니다.");
 
     // 비즈니스 로직 에러
 

--- a/src/main/java/com/cheocharm/MapZ/common/exception/group/NotFoundGroupException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/group/NotFoundGroupException.java
@@ -1,0 +1,10 @@
+package com.cheocharm.MapZ.common.exception.group;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class NotFoundGroupException extends CustomException {
+    public NotFoundGroupException() {
+        super(ExceptionDetails.NOT_FOUND_GROUP);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/exception/user/NoPermissionUserException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/user/NoPermissionUserException.java
@@ -1,0 +1,10 @@
+package com.cheocharm.MapZ.common.exception.user;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class NoPermissionUserException extends CustomException {
+    public NoPermissionUserException() {
+        super(ExceptionDetails.NO_PERMISSION_USER);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/cheocharm/MapZ/common/interceptor/AuthInterceptor.java
@@ -18,7 +18,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws RuntimeException {
-        String token = request.getHeader("token");
+        String token = request.getHeader("accessToken");
 
         if (token == null) {
             throw new RuntimeException("token value null");

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -1,6 +1,7 @@
 package com.cheocharm.MapZ.group.domain;
 
 import com.cheocharm.MapZ.common.CommonResponse;
+import com.cheocharm.MapZ.group.domain.dto.ChangeGroupStatusDto;
 import com.cheocharm.MapZ.group.domain.dto.CreateGroupDto;
 import com.cheocharm.MapZ.group.domain.dto.GetGroupListDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,5 +35,13 @@ public class GroupController {
     @GetMapping
     public CommonResponse<List<GetGroupListDto>> getGroup() {
         return CommonResponse.success(groupService.getGroup());
+    }
+
+    @Operation(description = "그룹 공개여부 변경")
+    @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
+    @PatchMapping("/status")
+    public CommonResponse<?> changeGroupStatus(@RequestBody @Valid ChangeGroupStatusDto changeGroupStatusDto) {
+        groupService.changeGroupStatus(changeGroupStatusDto);
+        return CommonResponse.success();
     }
 }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupEntity.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupEntity.java
@@ -26,11 +26,18 @@ public class GroupEntity extends BaseEntity {
 
     private String groupUUID;
 
+    private boolean openStatus;
+
     @Builder
-    public GroupEntity(String groupName, String bio, String groupImageUrl, String groupUUID) {
+    public GroupEntity(String groupName, String bio, String groupImageUrl, String groupUUID, boolean openStatus) {
         this.groupName = groupName;
         this.bio = bio;
         this.groupImageUrl = groupImageUrl;
         this.groupUUID = groupUUID;
+        this.openStatus = openStatus;
+    }
+
+    public void changeGroupStatus(boolean changeStatus) {
+        this.openStatus = changeStatus;
     }
 }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/ChangeGroupStatusDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/ChangeGroupStatusDto.java
@@ -1,0 +1,15 @@
+package com.cheocharm.MapZ.group.domain.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class ChangeGroupStatusDto {
+    @NotNull
+    private String group;
+
+    @NotNull
+    private Boolean changeStatus;
+
+}

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/CreateGroupDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/CreateGroupDto.java
@@ -13,4 +13,7 @@ public class CreateGroupDto {
 
     @NotNull
     private String bio;
+
+    @NotNull
+    private Boolean changeStatus;
 }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/GetGroupListDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/GetGroupListDto.java
@@ -1,12 +1,15 @@
 package com.cheocharm.MapZ.group.domain.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @Builder
 public class GetGroupListDto {
 
+    String groupName;
     String groupImageUrl;
     int count;
     List<String> userImageUrlList;

--- a/src/main/java/com/cheocharm/MapZ/user/domain/dto/MapZSignUpDto.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/dto/MapZSignUpDto.java
@@ -16,8 +16,6 @@ public class MapZSignUpDto {
     @NotNull @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,12}$" , message = "닉네임은 특수문자를 포함하지 않은 2~12자리여야 합니다.")
     String username;
 
-    MultipartFile userImage;
-
     @NotNull
     Boolean pushAgreement;
 }


### PR DESCRIPTION
메인은 그룹 공개여부 추가 이에 따른 변경사항은 다음과 같습니다.

- GroupEntity에 공개여부 필드 및 변경메서드 추가
- 그룹장만 변경할 수 있도록 하기위해 UserRole을 통해 검증하여 예외 추가
- 그룹 못찾을시 예외 발생하도록 추가
- 그룹 공개여부 필드 추가에 따른 Service, Controller 작성

이외 자잘한 것들 수정
AccessToken 헤더명 변경, Serializer 가 정상작동이 안되어 그룹조회 Dto에 Getter 추가, 회원가입시 안쓰는 Dto 클래스 필드 제거... 등등