### PR TITLE
feat: 그룹 검색 페이징 API

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/util/PagingUtils.java
+++ b/src/main/java/com/cheocharm/MapZ/common/util/PagingUtils.java
@@ -1,0 +1,24 @@
+package com.cheocharm.MapZ.common.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class PagingUtils {
+
+    public static final String FIELD_CREATED_AT = "createdAt";
+
+    public static final Integer GROUP_SIZE = 10;
+
+    public static Pageable applyPageConfigBy(int page, int size) {
+        return PageRequest.of(page, size);
+    }
+
+    public static Pageable applyAscPageConfigBy(int page, int size, String property) {
+        return PageRequest.of(page, size, Sort.Direction.ASC, property);
+    }
+
+    public static Pageable applyDescPageConfigBy(int page, int size, String property) {
+        return PageRequest.of(page, size, Sort.Direction.DESC, property);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/util/QuerydslSupport.java
+++ b/src/main/java/com/cheocharm/MapZ/common/util/QuerydslSupport.java
@@ -1,0 +1,55 @@
+package com.cheocharm.MapZ.common.util;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+public class QuerydslSupport {
+
+    public static <T> Slice<T> fetchSlice(JPAQuery<T> query, Pageable pageable) {
+        int pageSize = pageable.getPageSize();
+
+        List<T> content = query
+                .offset(pageable.getOffset())
+                .limit(pageSize + 1)
+                .fetch();
+
+        return new SliceImpl<>(content, pageable, isHasNext(pageSize, content));
+    }
+
+    public static <T> Slice<T> fetchSlice(Class<? extends T> type, PathMetadata pathMetadata, JPAQuery<T> query, Pageable pageable) {
+        Sort.Order order = pageable.getSort().iterator().next();
+
+        int pageSize = pageable.getPageSize();
+
+        List<T> content = query
+                .orderBy(getOrderSpecifier(type, pathMetadata, order))
+                .offset(pageable.getOffset())
+                .limit(pageSize + 1)
+                .fetch();
+
+        return new SliceImpl<>(content, pageable, isHasNext(pageSize, content));
+    }
+
+    private static <T> OrderSpecifier<?> getOrderSpecifier(Class<? extends T> type, PathMetadata pathMetadata, Sort.Order order) {
+        PathBuilder<? extends T> pathBuilder = new PathBuilder<T>(type, pathMetadata);
+        return new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, pathBuilder.get(order.getProperty()));
+    }
+
+    private static <T> boolean isHasNext(int pageSize, List<T> content) {
+        boolean hasNext = false;
+        if (pageSize < content.size()) {
+            hasNext = true;
+            content.remove(pageSize);
+        }
+        return hasNext;
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @Tag(name = "GroupController")
 @RequiredArgsConstructor
@@ -34,8 +33,8 @@ public class GroupController {
     @Operation(description = "그룹 선택을 위한 그룹 조회")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
     @GetMapping
-    public CommonResponse<List<GetGroupListDto>> getGroup() {
-        return CommonResponse.success(groupService.getGroup());
+    public CommonResponse<GetGroupListDto> getGroup(@RequestBody @Valid SearchGroupDto searchGroupDto) {
+        return CommonResponse.success(groupService.getGroup(searchGroupDto));
     }
 
     @Operation(description = "그룹 공개여부 변경")

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/GetGroupListDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/GetGroupListDto.java
@@ -9,8 +9,15 @@ import java.util.List;
 @Builder
 public class GetGroupListDto {
 
-    String groupName;
-    String groupImageUrl;
-    int count;
-    List<String> userImageUrlList;
+    Boolean hasNextPage;
+    List<GroupList> groupList;
+
+    @Getter
+    @Builder
+    public static class GroupList {
+        String groupName;
+        String groupImageUrl;
+        int count;
+        List<String> userImageUrlList;
+    }
 }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/SearchGroupDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/SearchGroupDto.java
@@ -1,0 +1,9 @@
+package com.cheocharm.MapZ.group.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SearchGroupDto {
+    Integer page;
+    String searchName;
+}

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/SearchGroupDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/SearchGroupDto.java
@@ -2,8 +2,14 @@ package com.cheocharm.MapZ.group.domain.dto;
 
 import lombok.Getter;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 public class SearchGroupDto {
+
+    @NotNull
     Integer page;
+
+    @NotNull
     String searchName;
 }

--- a/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustom.java
@@ -3,11 +3,15 @@ package com.cheocharm.MapZ.usergroup.repository;
 import com.cheocharm.MapZ.group.domain.GroupEntity;
 import com.cheocharm.MapZ.user.domain.UserEntity;
 import com.cheocharm.MapZ.usergroup.UserGroupEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 public interface UserGroupRepositoryCustom {
     List<UserGroupEntity> fetchJoinByUserEntity(UserEntity userEntity);
+
+    Slice<UserGroupEntity> fetchByUserEntityAndSearchNameAndOrderByUserName(UserEntity userEntity, String searchName, Pageable pageable);
 
     List<String> findUserImage(GroupEntity groupEntity);
 }

--- a/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustomImpl.java
@@ -7,10 +7,13 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static com.cheocharm.MapZ.common.util.QuerydslSupport.*;
 import static com.cheocharm.MapZ.group.domain.QGroupEntity.*;
 import static com.cheocharm.MapZ.user.domain.QUserEntity.*;
 import static com.cheocharm.MapZ.usergroup.QUserGroupEntity.*;
@@ -26,6 +29,17 @@ public class UserGroupRepositoryCustomImpl implements UserGroupRepositoryCustom 
         return fetchJoinQuery()
                 .where(userEq(userEntity))
                 .fetch();
+    }
+
+    @Override
+    public Slice<UserGroupEntity> fetchByUserEntityAndSearchNameAndOrderByUserName(UserEntity userEntity, String searchName, Pageable pageable) {
+        JPAQuery<UserGroupEntity> query = fetchJoinQuery()
+                .orderBy(userGroupEntity.groupEntity.groupName.asc())
+                .where(userGroupEntity.groupEntity.groupName.contains(searchName)
+                        .and(userEq(userEntity))
+                );
+
+        return fetchSlice(query, pageable);
     }
 
     @Override


### PR DESCRIPTION
Querydsl 메서드 작성시에 동적정렬을 사용해서 정렬하고 싶었는데
DB 설계와 맞지 않아서 따로 정렬하도록 메서드를 작성했습니다.

