### PR TITLE
feat: 토큰 만료 상태코드 변경

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/CommonResponse.java
+++ b/src/main/java/com/cheocharm/MapZ/common/CommonResponse.java
@@ -39,12 +39,4 @@ public class CommonResponse<T> {
                 .data(null)
                 .build();
     }
-
-    public static <T> CommonResponse<T> expiredToken() {
-        return CommonResponse.<T>builder()
-                .statusCode(HttpStatus.UNAUTHORIZED.value())
-                .message(HttpStatus.UNAUTHORIZED.toString())
-                .data(null)
-                .build();
-    }
 }

--- a/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
@@ -18,7 +18,7 @@ public enum ExceptionDetails {
 
     // 사용자 관련 에러
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "2001", "유효하지 않은 JWT 입니다. 토큰을 다시 확인해주세요."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "2002", "만료된 JWT 입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "2002", "만료된 JWT 입니다."),
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "2003", "중복된 이메일입니다."),
     DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "2004", "중복된 닉네임입니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "2005", "가입된 사용자가 아닙니다."),

--- a/src/main/java/com/cheocharm/MapZ/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.cheocharm.MapZ.common.exception;
 
 import com.cheocharm.MapZ.common.CommonResponse;
+import com.cheocharm.MapZ.common.exception.jwt.JwtExpiredException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -12,31 +15,38 @@ import javax.validation.ConstraintViolationException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    protected CommonResponse handleCustomException(CustomException ex) {
+    protected CommonResponse<?> handleCustomException(CustomException ex) {
         return CommonResponse.fail(ex.getStatusCode(), ex.getCustomCode(), ex.getMessage());
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    protected CommonResponse handleNoHandlerFoundException() {
+    protected CommonResponse<?> handleNoHandlerFoundException() {
         ExceptionDetails exceptionDetails = ExceptionDetails.NOT_FOUND_API;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected CommonResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+    protected CommonResponse<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         ExceptionDetails exceptionDetails = ExceptionDetails.INVALID_USER_INFO;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    protected CommonResponse handleConstraintViolationException(ConstraintViolationException ex) {
+    protected CommonResponse<?> handleConstraintViolationException(ConstraintViolationException ex) {
         ExceptionDetails exceptionDetails = ExceptionDetails.CONSTRAINT_VIOLATION;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
-    protected CommonResponse handleException() {
+    protected CommonResponse<?> handleException() {
         ExceptionDetails exceptionDetails = ExceptionDetails.INTERNAL_SERVER_ERROR;
+        return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(JwtExpiredException.class)
+    protected CommonResponse<?> handleJwtExpiredException() {
+        ExceptionDetails exceptionDetails = ExceptionDetails.EXPIRED_TOKEN;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage());
     }
 }


### PR DESCRIPTION
토큰 만료가 ExceptionHandler에서 처리되기 때문에 기본적으로 ExceptionDetails에 있는 상태코드가 아니다.
그리하여 ResponseStatus 어노테이션을 추가해서 200에서 401로 변경