### PR TITLE
feat: 그룹 가입 신청시 이미 참여했거나 신청한 유저인지 판별

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -49,9 +49,8 @@ public class GroupController {
     @Operation(description = "그룹 참가 신청")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
     @PostMapping("/join")
-    public CommonResponse<?> joinGroup(@RequestBody @Valid JoinGroupDto joinGroupDto) {
-        groupService.joinGroup(joinGroupDto);
-        return CommonResponse.success();
+    public CommonResponse<JoinGroupResultDto> joinGroup(@RequestBody @Valid JoinGroupDto joinGroupDto) {
+        return CommonResponse.success(groupService.joinGroup(joinGroupDto));
     }
 
     @Operation(description = "그룹 참가 신청 변경")

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/JoinGroupResultDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/JoinGroupResultDto.java
@@ -1,0 +1,11 @@
+package com.cheocharm.MapZ.group.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JoinGroupResultDto {
+    private Boolean alreadyJoin;
+    private String status;
+}


### PR DESCRIPTION
무한으로 그룹가입신청할 수 있었지만 이를 수정해서 가입되있거나 가입신청했으면 다시 누르지 않도록 방지