### PR TITLE
feat: 페이징 API 커서 기능 추가

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/util/PagingUtils.java
+++ b/src/main/java/com/cheocharm/MapZ/common/util/PagingUtils.java
@@ -13,11 +13,20 @@ public class PagingUtils {
     public static final Integer GROUP_SIZE = 10;
     public static final Integer USER_SIZE = 10;
 
+    private static final Long DEFAULT_CURSOR_ID = Long.MAX_VALUE;
+
     public static Pageable applyAscPageConfigBy(int page, int size, String property) {
         return PageRequest.of(page, size, Sort.Direction.ASC, property);
     }
 
     public static Pageable applyDescPageConfigBy(int page, int size, String property) {
         return PageRequest.of(page, size, Sort.Direction.DESC, property);
+    }
+
+    public static Long applyCursorId(Long cursorId) {
+        if (cursorId == 0) {
+            return DEFAULT_CURSOR_ID;
+        }
+        return cursorId;
     }
 }

--- a/src/main/java/com/cheocharm/MapZ/common/util/QuerydslSupport.java
+++ b/src/main/java/com/cheocharm/MapZ/common/util/QuerydslSupport.java
@@ -14,18 +14,7 @@ import java.util.List;
 
 public class QuerydslSupport {
 
-    public static <T> Slice<T> fetchSlice(JPAQuery<T> query, Pageable pageable) {
-        int pageSize = pageable.getPageSize();
-
-        List<T> content = query
-                .offset(pageable.getOffset())
-                .limit(pageSize + 1)
-                .fetch();
-
-        return new SliceImpl<>(content, pageable, isHasNext(pageSize, content));
-    }
-
-    public static <T> Slice<T> fetchSlice(Class<? extends T> type, PathMetadata pathMetadata, JPAQuery<T> query, Pageable pageable) {
+    public static <T> Slice<T> fetchSliceByOffset(Class<? extends T> type, PathMetadata pathMetadata, JPAQuery<T> query, Pageable pageable) {
         Sort.Order order = pageable.getSort().iterator().next();
 
         int pageSize = pageable.getPageSize();
@@ -38,6 +27,20 @@ public class QuerydslSupport {
 
         return new SliceImpl<>(content, pageable, isHasNext(pageSize, content));
     }
+
+    public static <T> Slice<T> fetchSliceByCursor(Class<? extends T> type, PathMetadata pathMetadata, JPAQuery<T> query, Pageable pageable) {
+        Sort.Order order = pageable.getSort().iterator().next();
+
+        int pageSize = pageable.getPageSize();
+
+        List<T> content = query
+                .orderBy(getOrderSpecifier(type, pathMetadata, order))
+                .limit(pageSize + 1)
+                .fetch();
+
+        return new SliceImpl<>(content, pageable, isHasNext(pageSize, content));
+    }
+    
 
     private static <T> OrderSpecifier<?> getOrderSpecifier(Class<? extends T> type, PathMetadata pathMetadata, Sort.Order order) {
         PathBuilder<? extends T> pathBuilder = new PathBuilder<T>(type, pathMetadata);

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -34,8 +34,8 @@ public class GroupController {
     @Operation(description = "그룹 참가를 위한 그룹 조회")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
     @GetMapping
-    public CommonResponse<PagingGetGroupListDto> getGroup(@RequestParam String groupName, @RequestParam Integer page) {
-        return CommonResponse.success(groupService.getGroup(groupName, page));
+    public CommonResponse<PagingGetGroupListDto> getGroup(@RequestParam String groupName, @RequestParam Long cursorId, @RequestParam Integer page) {
+        return CommonResponse.success(groupService.getGroup(groupName, cursorId, page));
     }
 
     @Operation(description = "그룹 공개여부 변경")

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupService.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupService.java
@@ -77,11 +77,11 @@ public class GroupService {
         );
     }
 
-    public PagingGetGroupListDto getGroup(String groupName, Integer page) {
-
+    public PagingGetGroupListDto getGroup(String groupName, Long cursorId, Integer page) {
         Slice<GroupEntity> content = groupRepository.findByGroupName(
                 groupName,
-                applyAscPageConfigBy(page, GROUP_SIZE, FIELD_GROUP_NAME)
+                applyCursorId(cursorId),
+                applyDescPageConfigBy(page, GROUP_SIZE, FIELD_CREATED_AT)
         );
 
         List<GroupEntity> groupEntityList = content.getContent();
@@ -95,14 +95,12 @@ public class GroupService {
                                 .createdAt(groupEntity.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
                                 .userImageUrlList(userGroupRepository.findUserImage(groupEntity))
                                 .count(getCount(groupEntity))
+                                .groupId(groupEntity.getId())
                                 .build()
                 )
                 .collect(Collectors.toList());
 
-        return PagingGetGroupListDto.builder()
-                .hasNextPage(content.hasNext())
-                .groupList(groupList)
-                .build();
+        return new PagingGetGroupListDto(content.hasNext(), groupList);
     }
 
     @Transactional

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/PagingGetGroupListDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/PagingGetGroupListDto.java
@@ -1,12 +1,13 @@
 package com.cheocharm.MapZ.group.domain.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class PagingGetGroupListDto {
 
     private Boolean hasNextPage;
@@ -17,6 +18,7 @@ public class PagingGetGroupListDto {
     public static class GroupList {
         private String groupName;
         private String groupImageUrl;
+        private Long groupId;
         private String bio;
         private String createdAt;
         private int count;

--- a/src/main/java/com/cheocharm/MapZ/group/domain/repository/GroupRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/repository/GroupRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface GroupRepositoryCustom {
-    Slice<GroupEntity> findByGroupName(String searchName, Pageable pageable);
+    Slice<GroupEntity> findByGroupName(String searchName, Long page, Pageable pageable);
 }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/repository/GroupRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/repository/GroupRepositoryCustomImpl.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import static com.cheocharm.MapZ.common.util.QuerydslSupport.fetchSlice;
+import static com.cheocharm.MapZ.common.util.QuerydslSupport.*;
 import static com.cheocharm.MapZ.group.domain.QGroupEntity.*;
 
 @RequiredArgsConstructor
@@ -16,14 +16,15 @@ public class GroupRepositoryCustomImpl implements GroupRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<GroupEntity> findByGroupName(String groupName, Pageable pageable) {
+    public Slice<GroupEntity> findByGroupName(String groupName, Long cursorId, Pageable pageable) {
         JPAQuery<GroupEntity> query = queryFactory
                 .selectFrom(groupEntity)
                 .where(groupEntity.groupName.contains(groupName)
                         .and(groupEntity.openStatus.eq(true))
+                        .and(groupEntity.id.lt(cursorId))
                 );
 
-        return fetchSlice(groupEntity.getType(), groupEntity.getMetadata(), query, pageable);
+        return fetchSliceByCursor(groupEntity.getType(), groupEntity.getMetadata(), query, pageable);
     }
 
 }

--- a/src/main/java/com/cheocharm/MapZ/user/domain/UserController.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/UserController.java
@@ -76,8 +76,8 @@ public class UserController {
     @Operation(description = "그룹 초대를 위한 유저 검색")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
     @GetMapping("/user")
-    public CommonResponse<GetUserListDto> searchUser(@RequestParam Integer page, @RequestParam String searchName, @RequestParam String groupName) {
-        return CommonResponse.success(userService.searchUser(page, searchName, groupName));
+    public CommonResponse<GetUserListDto> searchUser(@RequestParam Integer page, @RequestParam Long cursorId, @RequestParam String searchName, @RequestParam String groupName) {
+        return CommonResponse.success(userService.searchUser(page, cursorId, searchName, groupName));
     }
 
     @Operation(description = "마이페이지 닉네임, 프로필 이미지 가져오기")

--- a/src/main/java/com/cheocharm/MapZ/user/domain/UserService.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/UserService.java
@@ -226,11 +226,12 @@ public class UserService {
         userEntity.updatePassword(password);
     }
 
-    public GetUserListDto searchUser(Integer page, String searchName, String groupName) {
+    public GetUserListDto searchUser(Integer page, Long cursorId, String searchName, String groupName) {
         Slice<UserEntity> content = userRepository.fetchByUserEntityAndSearchName(
                 UserThreadLocal.get(),
                 searchName,
-                applyAscPageConfigBy(page, USER_SIZE, FIELD_USERNAME)
+                applyCursorId(cursorId),
+                applyDescPageConfigBy(page, USER_SIZE, FIELD_CREATED_AT)
         );
 
         final List<UserEntity> userEntityList = content.getContent();
@@ -245,15 +246,13 @@ public class UserService {
                         GetUserListDto.UserList.builder()
                                 .username(userEntity.getUsername())
                                 .userImageUrl(userEntity.getUserImageUrl())
+                                .userId(userEntity.getId())
                                 .member(isMember(userEntity, groupMemberList))
                                 .build()
                 )
                 .collect(Collectors.toList());
 
-        return GetUserListDto.builder()
-                .hasNext(content.hasNext())
-                .userList(userList)
-                .build();
+        return new GetUserListDto(content.hasNext(), userList);
     }
 
     public MyPageInfoDto getMyPageInfo() {

--- a/src/main/java/com/cheocharm/MapZ/user/domain/dto/GetUserListDto.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/dto/GetUserListDto.java
@@ -1,13 +1,14 @@
 package com.cheocharm.MapZ.user.domain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class GetUserListDto {
     private Boolean hasNext;
     private List<UserList> userList;
@@ -17,6 +18,7 @@ public class GetUserListDto {
     public static class UserList {
         private String username;
         private String userImageUrl;
+        private Long userId;
         @Schema(description = "그룹에 포함되어 있는 멤버면 true, 아니면 false")
         private Boolean member;
     }

--- a/src/main/java/com/cheocharm/MapZ/user/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/repository/UserRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 public interface UserRepositoryCustom {
-    Slice<UserEntity> fetchByUserEntityAndSearchName(UserEntity userEntity, String searchName, Pageable pageable);
+    Slice<UserEntity> fetchByUserEntityAndSearchName(UserEntity userEntity, String searchName, Long cursorId, Pageable pageable);
 
     List<UserEntity> getUserEntityListByUsernameList(List<String> username);
 }

--- a/src/main/java/com/cheocharm/MapZ/user/domain/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/repository/UserRepositoryCustomImpl.java
@@ -21,13 +21,14 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<UserEntity> fetchByUserEntityAndSearchName(UserEntity userCond, String searchName, Pageable pageable) {
+    public Slice<UserEntity> fetchByUserEntityAndSearchName(UserEntity userCond, String searchName, Long cursorId, Pageable pageable) {
         JPAQuery<UserEntity> query = queryFactory
                 .selectFrom(userEntity)
                 .where(userEntity.username.contains(searchName)
                         .and(userNe(userCond))
+                        .and(userEntity.id.lt(cursorId))
                 );
-        return fetchSlice(userEntity.getType(), userEntity.getMetadata(), query, pageable);
+        return fetchSliceByCursor(userEntity.getType(), userEntity.getMetadata(), query, pageable);
     }
 
     @Override


### PR DESCRIPTION
offset 사용시 레코드가 많아질수록 성능이 좋지 못함.
기존 로직은 중복 레코드 조회 가능성이 있기에 커서 기능 사용
무분별한 Builder 패턴 지양 -> 지속적으로 생성자 사용할 수 있는 부분은 수정 예정