### PR TITLE
feat: 그룹에서 내보내기 API

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/config/SecurityConfig.java
+++ b/src/main/java/com/cheocharm/MapZ/common/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers(HttpMethod.POST, "/api/group/invite").authenticated()
                     .antMatchers(HttpMethod.GET, "/api/group/mygroup").authenticated()
                     .antMatchers(HttpMethod.GET, "/api/group/member").authenticated()
+                    .antMatchers(HttpMethod.DELETE, "/api/group/user").authenticated()
 
                     //diary
                     .antMatchers(HttpMethod.PUT, "/api/diary/like").authenticated()

--- a/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
@@ -34,6 +34,7 @@ public enum ExceptionDetails {
 
     //사용자 그룹(userGroup) 예외
     NOT_FOUND_USERGROUP(HttpStatus.NOT_FOUND, "4001", "해당되는 유저그룹 테이블 데이터가 없습니다."),
+    SELF_KICK(HttpStatus.BAD_REQUEST, "4002", "내보내려는 유저와 요청한 유저가 동일합니다."),
 
     //다이어리 예외
     NOT_FOUND_DIARY(HttpStatus.NOT_FOUND, "5001", "게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/cheocharm/MapZ/common/exception/usergroup/SelfKickException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/usergroup/SelfKickException.java
@@ -1,0 +1,11 @@
+package com.cheocharm.MapZ.common.exception.usergroup;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class SelfKickException extends CustomException {
+
+    public SelfKickException() {
+        super(ExceptionDetails.SELF_KICK);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -99,4 +99,11 @@ public class GroupController {
         return CommonResponse.success(groupService.getMember(groupId));
     }
 
+    @Operation(description = "그룹에서 내보내기")
+    @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
+    @DeleteMapping("/user")
+    public CommonResponse<?> kickUser(@RequestBody @Valid KickUserDto kickUserDto) {
+        groupService.kickUser(kickUserDto);
+        return CommonResponse.success();
+    }
 }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/KickUserDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/KickUserDto.java
@@ -1,0 +1,14 @@
+package com.cheocharm.MapZ.group.domain.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class KickUserDto {
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private Long groupId;
+}

--- a/src/main/java/com/cheocharm/MapZ/usergroup/InvitationStatus.java
+++ b/src/main/java/com/cheocharm/MapZ/usergroup/InvitationStatus.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum InvitationStatus {
-    PENDING("대기중"), ACCEPT("수락완료"), REFUSE("거절"), SEND("초대장보냄");
+    PENDING("대기중"), ACCEPT("수락완료"), SEND("초대장보냄");
 
     private final String status;
 

--- a/src/main/java/com/cheocharm/MapZ/usergroup/UserGroupEntity.java
+++ b/src/main/java/com/cheocharm/MapZ/usergroup/UserGroupEntity.java
@@ -45,10 +45,6 @@ public class UserGroupEntity extends BaseEntity {
         this.invitationStatus = InvitationStatus.ACCEPT;
     }
 
-    public void refuseUser() {
-        this.invitationStatus = InvitationStatus.REFUSE;
-    }
-
     public void changeChief(UserGroupEntity chiefUser, UserGroupEntity targetUser) {
         chiefUser.userRole = UserRole.MEMBER;
         targetUser.userRole = UserRole.CHIEF;


### PR DESCRIPTION
그룹에서 유저 내보내기나, 초대 거절, 신청 거절시에 레코드 삭제하기로 했기에
Enum에 거절 상태를 제거했습니다~
그룹에서 내보내기 예외상황있으면 말씀해주세요