### PR TITLE
feat: 그룹 내보내기, 나가기, 정보변경 로직 추가

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/cheocharm/MapZ/comment/domain/repository/CommentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+public interface CommentRepository extends JpaRepository<CommentEntity, Long>, CommentRepositoryCustom{
     @Modifying
     @Query("delete from CommentEntity c where c.parentId in :id")
     void deleteAllByIdInQuery(@Param("id") Long id);

--- a/src/main/java/com/cheocharm/MapZ/comment/domain/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/comment/domain/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.cheocharm.MapZ.comment.domain.repository;
+
+import com.cheocharm.MapZ.diary.domain.DiaryEntity;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    void deleteAllByDiaryEntityList(List<DiaryEntity> diaryEntityList);
+}

--- a/src/main/java/com/cheocharm/MapZ/comment/domain/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/comment/domain/repository/CommentRepositoryCustomImpl.java
@@ -1,0 +1,23 @@
+package com.cheocharm.MapZ.comment.domain.repository;
+
+import com.cheocharm.MapZ.diary.domain.DiaryEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.cheocharm.MapZ.comment.domain.QCommentEntity.*;
+
+@RequiredArgsConstructor
+public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteAllByDiaryEntityList(List<DiaryEntity> diaryEntityList) {
+        queryFactory
+                .delete(commentEntity)
+                .where(commentEntity.diaryEntity.in(diaryEntityList))
+                .execute();
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/config/SecurityConfig.java
+++ b/src/main/java/com/cheocharm/MapZ/common/config/SecurityConfig.java
@@ -63,10 +63,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     //group
                     .antMatchers(HttpMethod.POST, "/api/group").authenticated()
                     .antMatchers(HttpMethod.GET, "/api/group").authenticated()
-                    .antMatchers(HttpMethod.PATCH, "/api/group/status").authenticated()
+                    .antMatchers(HttpMethod.PATCH, "/api/group").authenticated()
                     .antMatchers(HttpMethod.POST, "/api/group/join").authenticated()
                     .antMatchers(HttpMethod.PATCH, "/api/group/join").authenticated()
                     .antMatchers(HttpMethod.PATCH, "/api/group/exit").authenticated()
+                    .antMatchers(HttpMethod.PATCH, "/api/group/chief").authenticated()
                     .antMatchers(HttpMethod.POST, "/api/group/invite").authenticated()
                     .antMatchers(HttpMethod.GET, "/api/group/mygroup").authenticated()
                     .antMatchers(HttpMethod.GET, "/api/group/member").authenticated()

--- a/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
@@ -35,6 +35,7 @@ public enum ExceptionDetails {
     //사용자 그룹(userGroup) 예외
     NOT_FOUND_USERGROUP(HttpStatus.NOT_FOUND, "4001", "해당되는 유저그룹 테이블 데이터가 없습니다."),
     SELF_KICK(HttpStatus.BAD_REQUEST, "4002", "내보내려는 유저와 요청한 유저가 동일합니다."),
+    NOT_ACCEPTED_USER(HttpStatus.BAD_REQUEST, "4003", "수락된 유저가 아닙니다."),
 
     //다이어리 예외
     NOT_FOUND_DIARY(HttpStatus.NOT_FOUND, "5001", "게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/cheocharm/MapZ/common/exception/usergroup/NotAcceptedUserException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/usergroup/NotAcceptedUserException.java
@@ -1,0 +1,11 @@
+package com.cheocharm.MapZ.common.exception.usergroup;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class NotAcceptedUserException extends CustomException {
+
+    public NotAcceptedUserException() {
+        super(ExceptionDetails.NOT_ACCEPTED_USER);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.cheocharm.MapZ.diary.domain.respository;
 
+import com.cheocharm.MapZ.diary.domain.DiaryEntity;
 import com.cheocharm.MapZ.diary.domain.DiaryLikeEntity;
 import com.cheocharm.MapZ.diary.domain.respository.vo.MyLikeDiaryVO;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,5 @@ public interface DiaryLikeRepositoryCustom {
 
     Slice<MyLikeDiaryVO> findByUserId(Long userId, Long cursorId, Pageable pageable);
 
+    void deleteAllByDiaryEntityList(List<DiaryEntity> diaryEntityList);
 }

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.cheocharm.MapZ.diary.domain.respository;
 
+import com.cheocharm.MapZ.diary.domain.DiaryEntity;
 import com.cheocharm.MapZ.diary.domain.DiaryLikeEntity;
 import com.cheocharm.MapZ.diary.domain.respository.vo.MyLikeDiaryVO;
 import com.cheocharm.MapZ.diary.domain.respository.vo.QMyLikeDiaryVO;
@@ -55,6 +56,14 @@ public class DiaryLikeRepositoryCustomImpl implements DiaryLikeRepositoryCustom{
                 .groupBy(diaryEntity.id);
 
         return fetchSliceByCursor(diaryEntity.getType(), diaryEntity.getMetadata(), query, pageable);
+    }
+
+    @Override
+    public void deleteAllByDiaryEntityList(List<DiaryEntity> diaryEntityList) {
+        queryFactory
+                .delete(diaryLikeEntity)
+                .where(diaryLikeEntity.diaryEntity.in(diaryEntityList))
+                .execute();
     }
 
     private BooleanExpression diaryIdEq(Long diaryId) {

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustom.java
@@ -11,4 +11,8 @@ public interface DiaryRepositoryCustom {
     List<DiaryEntity> findByUserIdAndGroupId(Long userId, Long groupId);
 
     Slice<MyDiaryVO> findByUserId(Long userId, Long cursorId, Pageable pageable);
+
+    void deleteAllByUserId(Long userId);
+
+    List<DiaryEntity> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustomImpl.java
@@ -53,6 +53,22 @@ public class DiaryRepositoryCustomImpl implements DiaryRepositoryCustom {
         return fetchSliceByCursor(diaryEntity.getType(), diaryEntity.getMetadata(), query, pageable);
     }
 
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        queryFactory
+                .delete(diaryEntity)
+                .where(userIdEq(userId))
+                .execute();
+    }
+
+    @Override
+    public List<DiaryEntity> findAllByUserId(Long userId) {
+        return queryFactory
+                .selectFrom(diaryEntity)
+                .where(userIdEq(userId))
+                .fetch();
+    }
+
     private BooleanExpression userIdEq(Long userId) {
         return diaryEntity.userEntity.id.eq(userId);
     }

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -38,11 +38,13 @@ public class GroupController {
         return CommonResponse.success(groupService.getGroup(groupName, cursorId, page));
     }
 
-    @Operation(description = "그룹 공개여부 변경")
+    @Operation(description = "그룹 정보 변경")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
-    @PatchMapping("/status")
-    public CommonResponse<?> changeGroupStatus(@RequestBody @Valid ChangeGroupStatusDto changeGroupStatusDto) {
-        groupService.changeGroupStatus(changeGroupStatusDto);
+    @PatchMapping
+    public CommonResponse<?> changeGroupInfo(
+            @RequestPart(value = "dto") @Valid ChangeGroupInfoDto changeGroupInfoDto,
+            @RequestPart(value="file", required = false) MultipartFile multipartFile) {
+        groupService.changeGroupInfo(changeGroupInfoDto, multipartFile);
         return CommonResponse.success();
     }
 

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupEntity.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupEntity.java
@@ -1,6 +1,7 @@
 package com.cheocharm.MapZ.group.domain;
 
 import com.cheocharm.MapZ.common.domain.BaseEntity;
+import com.cheocharm.MapZ.group.domain.dto.ChangeGroupInfoDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,8 +38,10 @@ public class GroupEntity extends BaseEntity {
         this.openStatus = openStatus;
     }
 
-    public void changeGroupStatus(boolean changeStatus) {
-        this.openStatus = changeStatus;
+    public void changeGroupInfo(ChangeGroupInfoDto changeGroupInfoDto) {
+        this.groupName = changeGroupInfoDto.getGroupName();
+        this.bio = changeGroupInfoDto.getBio();
+        this.openStatus = changeGroupInfoDto.getChangeStatus();
     }
 
     public void updateGroupImageUrl(String groupImageUrl) {

--- a/src/main/java/com/cheocharm/MapZ/group/domain/dto/ChangeGroupInfoDto.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/dto/ChangeGroupInfoDto.java
@@ -5,9 +5,15 @@ import lombok.Getter;
 import javax.validation.constraints.NotNull;
 
 @Getter
-public class ChangeGroupStatusDto {
+public class ChangeGroupInfoDto {
     @NotNull
     private Long groupId;
+
+    @NotNull
+    private String groupName;
+
+    @NotNull
+    private String bio;
 
     @NotNull
     private Boolean changeStatus;

--- a/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustomImpl.java
@@ -93,9 +93,8 @@ public class UserGroupRepositoryCustomImpl implements UserGroupRepositoryCustom 
     private JPAQuery<UserGroupEntity> fetchJoinQuery() {
         return queryFactory
                 .selectFrom(userGroupEntity)
-                .innerJoin(userGroupEntity.groupEntity, groupEntity)
-                .innerJoin(userGroupEntity.userEntity, userEntity)
-                .fetchJoin();
+                .innerJoin(userGroupEntity.groupEntity, groupEntity).fetchJoin()
+                .innerJoin(userGroupEntity.userEntity, userEntity).fetchJoin();
     }
 
     private JPAQuery<UserGroupEntity> fetchJoinUserEntity() {


### PR DESCRIPTION
Cascade로 삭제할때 편하게 하려 했는데, 쿼리가 많이 발생해서 벌크 연산 최대한 사용했습니다~
프론트에서 글쓰기 작업 완료되면 그때 이미지도 삭제하는 로직 추가해야겠네요.
(삭제 기능 만들때 참고자료 -> https://jojoldu.tistory.com/235)

그룹 정보는 모든 정보 변경 후 완료버튼을 통해서 수정하기로 픽스했으니 다음과 같이 DTO 바꿨습니다!
