### PR TITLE
refactor: 메서드네이밍, import 와일드카드 미사용, 비교연산 메서드 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
 
 	//for coordinate
 	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.9.Final'
+
+	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cheocharm/MapZ/common/log/response/ResponseLogSchema.java
+++ b/src/main/java/com/cheocharm/MapZ/common/log/response/ResponseLogSchema.java
@@ -1,7 +1,6 @@
 package com.cheocharm.MapZ.common.log.response;
 
 import com.cheocharm.MapZ.common.CommonResponse;
-import com.cheocharm.MapZ.common.exception.S3.FailConvertToFileException;
 import com.cheocharm.MapZ.common.exception.common.FailConvertToJsonException;
 import com.cheocharm.MapZ.common.util.ObjectMapperUtils;
 import lombok.Builder;

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
@@ -7,7 +7,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import java.util.List;

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryService.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryService.java
@@ -14,6 +14,7 @@ import com.cheocharm.MapZ.group.domain.GroupEntity;
 import com.cheocharm.MapZ.group.domain.repository.GroupRepository;
 import com.cheocharm.MapZ.user.domain.UserEntity;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
@@ -25,7 +26,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.cheocharm.MapZ.common.util.PagingUtils.*;
+import static com.cheocharm.MapZ.common.util.PagingUtils.applyCursorId;
+import static com.cheocharm.MapZ.common.util.PagingUtils.applyDescPageConfigBy;
+import static com.cheocharm.MapZ.common.util.PagingUtils.MY_LIKE_DIARY_SIZE;
+import static com.cheocharm.MapZ.common.util.PagingUtils.MY_DIARY_SIZE;
+import static com.cheocharm.MapZ.common.util.PagingUtils.FIELD_CREATED_AT;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -103,7 +108,7 @@ public class DiaryService {
     public void deleteDiary(DeleteDiaryDto deleteDiaryDto) {
         UserEntity userEntity = UserThreadLocal.get();
 
-        if (!deleteDiaryDto.getUserId().equals(userEntity.getId())) {
+        if (ObjectUtils.notEqual(deleteDiaryDto.getUserId(), userEntity.getId())) {
             throw new NoPermissionUserException();
         }
 

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustomImpl.java
@@ -13,12 +13,12 @@ import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-import static com.cheocharm.MapZ.comment.domain.QCommentEntity.*;
+import static com.cheocharm.MapZ.comment.domain.QCommentEntity.commentEntity;
 import static com.cheocharm.MapZ.common.util.QuerydslSupport.fetchSliceByCursor;
-import static com.cheocharm.MapZ.diary.domain.QDiaryEntity.*;
-import static com.cheocharm.MapZ.diary.domain.QDiaryLikeEntity.*;
-import static com.cheocharm.MapZ.group.domain.QGroupEntity.*;
-import static com.cheocharm.MapZ.user.domain.QUserEntity.*;
+import static com.cheocharm.MapZ.diary.domain.QDiaryEntity.diaryEntity;
+import static com.cheocharm.MapZ.diary.domain.QDiaryLikeEntity.diaryLikeEntity;
+import static com.cheocharm.MapZ.group.domain.QGroupEntity.groupEntity;
+import static com.cheocharm.MapZ.user.domain.QUserEntity.userEntity;
 
 @RequiredArgsConstructor
 public class DiaryLikeRepositoryCustomImpl implements DiaryLikeRepositoryCustom{

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustomImpl.java
@@ -12,10 +12,10 @@ import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-import static com.cheocharm.MapZ.comment.domain.QCommentEntity.*;
-import static com.cheocharm.MapZ.common.util.QuerydslSupport.*;
-import static com.cheocharm.MapZ.diary.domain.QDiaryEntity.*;
-import static com.cheocharm.MapZ.group.domain.QGroupEntity.*;
+import static com.cheocharm.MapZ.comment.domain.QCommentEntity.commentEntity;
+import static com.cheocharm.MapZ.common.util.QuerydslSupport.fetchSliceByCursor;
+import static com.cheocharm.MapZ.diary.domain.QDiaryEntity.diaryEntity;
+import static com.cheocharm.MapZ.group.domain.QGroupEntity.groupEntity;
 
 @RequiredArgsConstructor
 public class DiaryRepositoryCustomImpl implements DiaryRepositoryCustom {

--- a/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/GroupController.java
@@ -7,7 +7,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;

--- a/src/main/java/com/cheocharm/MapZ/group/domain/repository/GroupRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/group/domain/repository/GroupRepositoryCustomImpl.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import static com.cheocharm.MapZ.common.util.QuerydslSupport.*;
-import static com.cheocharm.MapZ.group.domain.QGroupEntity.*;
+import static com.cheocharm.MapZ.common.util.QuerydslSupport.fetchSliceByCursor;
+import static com.cheocharm.MapZ.group.domain.QGroupEntity.groupEntity;
 
 @RequiredArgsConstructor
 public class GroupRepositoryCustomImpl implements GroupRepositoryCustom {

--- a/src/main/java/com/cheocharm/MapZ/user/domain/UserController.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/UserController.java
@@ -9,7 +9,16 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;

--- a/src/main/java/com/cheocharm/MapZ/user/domain/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/user/domain/repository/UserRepositoryCustomImpl.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-import static com.cheocharm.MapZ.common.util.QuerydslSupport.*;
-import static com.cheocharm.MapZ.user.domain.QUserEntity.*;
+import static com.cheocharm.MapZ.common.util.QuerydslSupport.fetchSliceByCursor;
+import static com.cheocharm.MapZ.user.domain.QUserEntity.userEntity;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/usergroup/repository/UserGroupRepositoryCustomImpl.java
@@ -18,9 +18,9 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Optional;
 
-import static com.cheocharm.MapZ.group.domain.QGroupEntity.*;
-import static com.cheocharm.MapZ.user.domain.QUserEntity.*;
-import static com.cheocharm.MapZ.usergroup.QUserGroupEntity.*;
+import static com.cheocharm.MapZ.group.domain.QGroupEntity.groupEntity;
+import static com.cheocharm.MapZ.user.domain.QUserEntity.userEntity;
+import static com.cheocharm.MapZ.usergroup.QUserGroupEntity.userGroupEntity;
 
 @RequiredArgsConstructor
 @Component


### PR DESCRIPTION
같은 패키지에 import가 여러개면 자동으로 와일드 카드 사용으로 세팅되어 있을건데
아래 링크 참조해서 변경하시면 됩니다~
-> https://dev-kani.tistory.com/39

!Object.equals(Object1) 와 같은 비교연산을 사용할때 헷갈리는 경우가 있기에
직관적으로 ObjectUtils.notEqual()을 사용했습니다.

Enum 비교시 통일성을 위해 Objects.equals(Enum1, Enum2)로 비교하도록 했습니다