### PR TITLE
feat: 글쓰기 구현

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/config/SecurityConfig.java
+++ b/src/main/java/com/cheocharm/MapZ/common/config/SecurityConfig.java
@@ -81,6 +81,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers(HttpMethod.GET, "/api/diary/like").authenticated()
                     .antMatchers(HttpMethod.GET, "/api/diary/mylike").authenticated()
                     .antMatchers(HttpMethod.GET,"/api/diary/my").authenticated()
+                    .antMatchers(HttpMethod.POST, "/api/diary/image").authenticated()
+                    .antMatchers(HttpMethod.POST, "/api/diary/write").authenticated()
+                    .antMatchers(HttpMethod.DELETE, "/api/diary/image").authenticated()
 
                     //commnet
                     .antMatchers(HttpMethod.POST, "/api/comment").authenticated()

--- a/src/main/java/com/cheocharm/MapZ/common/util/S3Utils.java
+++ b/src/main/java/com/cheocharm/MapZ/common/util/S3Utils.java
@@ -11,6 +11,9 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Component
@@ -47,6 +50,24 @@ public class S3Utils {
 
         return imageURL;
 
+    }
+
+    public List<String> uploadDiaryImage(List<MultipartFile> files, Long diaryId) {
+        String directory = DIARY.concat(String.valueOf(diaryId)).concat("/");
+        List<String> imageURLs = new ArrayList<>();
+        for (MultipartFile multipartFile : files) {
+            File file = convert(multipartFile);
+            String key = directory.concat(UUID.randomUUID().toString());
+            amazonS3Client.putObject(bucket, key, file);
+            imageURLs.add(amazonS3Client.getUrl(bucket, key).toString());
+        }
+        return imageURLs;
+    }
+
+    public void deleteDiaryImage(List<String> imageURLs) {
+        for (String imageURL : imageURLs) {
+            amazonS3Client.deleteObject(bucket, imageURL);
+        }
     }
 
     @SuppressWarnings({"ConstantConditions", "ResultOfMethodCallIgnored"})

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
@@ -2,6 +2,9 @@ package com.cheocharm.MapZ.diary.domain;
 
 import com.cheocharm.MapZ.common.CommonResponse;
 import com.cheocharm.MapZ.diary.domain.dto.*;
+import com.cheocharm.MapZ.diary.domain.dto.request.DeleteTempDiary;
+import com.cheocharm.MapZ.diary.domain.dto.request.WriteDiaryImageRequest;
+import com.cheocharm.MapZ.diary.domain.dto.response.WriteDiaryImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -13,7 +16,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -34,11 +39,28 @@ public class DiaryController {
         return CommonResponse.success();
     }
 
-    @Operation(description = "일기 작성")
+    @Operation(description = "일기 작성시 이미지 데이터 생성 (1차 요청)")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
-    @PostMapping
+    @PostMapping("/image")
+    public CommonResponse<WriteDiaryImageResponse> writeDiaryImage(
+            @RequestPart(value = "dto") @Valid WriteDiaryImageRequest writeDiaryImageRequest,
+            @Parameter @RequestPart(value = "files") List<MultipartFile> files) {
+        return CommonResponse.success(diaryService.writeDiaryImage(writeDiaryImageRequest, files));
+    }
+
+    @Operation(description = "일기 본문까지 작성 완료 후 업데이트 (2차 요청)")
+    @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
+    @PostMapping("/write")
     public CommonResponse<?> writeDiary(@Parameter @RequestBody @Valid WriteDiaryDto writeDiaryDto) {
         diaryService.writeDiary(writeDiaryDto);
+        return CommonResponse.success();
+    }
+
+    @Operation(description = "예외 사항으로 인해 일기 작성을 취소하면 일기, 이미지 데이터 삭제 (1차 요청 후 상황에 맞게 호출) ")
+    @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
+    @DeleteMapping("/image")
+    public CommonResponse<?> deleteTempDiary(@Parameter @RequestBody @Valid DeleteTempDiary deleteTempDiary) {
+        diaryService.deleteTempDiary(deleteTempDiary);
         return CommonResponse.success();
     }
 

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
@@ -51,8 +51,8 @@ public class DiaryController {
     @Operation(description = "일기 본문까지 작성 완료 후 업데이트 (2차 요청)")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
     @PostMapping("/write")
-    public CommonResponse<?> writeDiary(@Parameter @RequestBody @Valid WriteDiaryDto writeDiaryDto) {
-        diaryService.writeDiary(writeDiaryDto);
+    public CommonResponse<?> writeDiary(@Parameter @RequestBody @Valid WriteDiaryRequest writeDiaryRequest) {
+        diaryService.writeDiary(writeDiaryRequest);
         return CommonResponse.success();
     }
 

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryController.java
@@ -2,7 +2,7 @@ package com.cheocharm.MapZ.diary.domain;
 
 import com.cheocharm.MapZ.common.CommonResponse;
 import com.cheocharm.MapZ.diary.domain.dto.*;
-import com.cheocharm.MapZ.diary.domain.dto.request.DeleteTempDiary;
+import com.cheocharm.MapZ.diary.domain.dto.request.DeleteTempDiaryRequest;
 import com.cheocharm.MapZ.diary.domain.dto.request.WriteDiaryImageRequest;
 import com.cheocharm.MapZ.diary.domain.dto.response.WriteDiaryImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -59,8 +59,8 @@ public class DiaryController {
     @Operation(description = "예외 사항으로 인해 일기 작성을 취소하면 일기, 이미지 데이터 삭제 (1차 요청 후 상황에 맞게 호출) ")
     @Parameter(name = "accessToken", in = ParameterIn.HEADER, required = true)
     @DeleteMapping("/image")
-    public CommonResponse<?> deleteTempDiary(@Parameter @RequestBody @Valid DeleteTempDiary deleteTempDiary) {
-        diaryService.deleteTempDiary(deleteTempDiary);
+    public CommonResponse<?> deleteTempDiary(@Parameter @RequestBody @Valid DeleteTempDiaryRequest deleteTempDiaryRequest) {
+        diaryService.deleteTempDiary(deleteTempDiaryRequest);
         return CommonResponse.success();
     }
 

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryEntity.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryEntity.java
@@ -27,6 +27,8 @@ public class DiaryEntity extends BaseEntity {
 
     private Point point;
 
+    private String address;
+
     @JoinColumn(name = "user_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private UserEntity userEntity;
@@ -35,18 +37,27 @@ public class DiaryEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private GroupEntity groupEntity;
 
-    @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.REMOVE)
-    private List<CommentEntity> commentEntityList = new ArrayList<>();
+    @OneToMany(mappedBy = "diaryEntity")
+    private List<CommentEntity> commentEntities = new ArrayList<>();
 
-    @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.REMOVE)
-    private List<DiaryLikeEntity> diaryLikeEntityList = new ArrayList<>();
+    @OneToMany(mappedBy = "diaryEntity")
+    private List<DiaryLikeEntity> diaryLikeEntities = new ArrayList<>();
+
+    @OneToMany(mappedBy = "diaryEntity")
+    private List<DiaryImageEntity> diaryImageEntities = new ArrayList<>();
 
     @Builder
-    public DiaryEntity(String title, String content, Point point, UserEntity userEntity, GroupEntity groupEntity) {
+    public DiaryEntity(String title, String content, Point point, String address, UserEntity userEntity, GroupEntity groupEntity) {
         this.title = title;
         this.content = content;
         this.point = point;
+        this.address = address;
         this.userEntity = userEntity;
         this.groupEntity = groupEntity;
+    }
+
+    public void write(String title, String content) {
+        this.title = title;
+        this.content = content;
     }
 }

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryImageEntity.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryImageEntity.java
@@ -2,10 +2,16 @@ package com.cheocharm.MapZ.diary.domain;
 
 import com.cheocharm.MapZ.common.domain.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Getter
 @Table(name = "Diary_Image")
@@ -19,4 +25,13 @@ public class DiaryImageEntity extends BaseEntity {
 
     @Column(name = "diary_image_url")
     private String diaryImageUrl;
+
+    private Integer imageOrder;
+
+    @Builder
+    public DiaryImageEntity(DiaryEntity diaryEntity, String diaryImageUrl, Integer imageOrder) {
+        this.diaryEntity = diaryEntity;
+        this.diaryImageUrl = diaryImageUrl;
+        this.imageOrder = imageOrder;
+    }
 }

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryService.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryService.java
@@ -71,11 +71,11 @@ public class DiaryService {
     }
 
     @Transactional
-    public void writeDiary(WriteDiaryDto writeDiaryDto) {
-        DiaryEntity diaryEntity = diaryRepository.findById(writeDiaryDto.getDiaryId())
+    public void writeDiary(WriteDiaryRequest writeDiaryRequest) {
+        DiaryEntity diaryEntity = diaryRepository.findById(writeDiaryRequest.getDiaryId())
                 .orElseThrow(NotFoundDiaryException::new);
 
-        diaryEntity.write(writeDiaryDto.getTitle(), writeDiaryDto.getContent());
+        diaryEntity.write(writeDiaryRequest.getTitle(), writeDiaryRequest.getContent());
     }
 
     public GetDiaryListDto getDiary(Long groupId) {

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryService.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/DiaryService.java
@@ -7,7 +7,7 @@ import com.cheocharm.MapZ.common.exception.user.NoPermissionUserException;
 import com.cheocharm.MapZ.common.interceptor.UserThreadLocal;
 import com.cheocharm.MapZ.common.util.S3Utils;
 import com.cheocharm.MapZ.diary.domain.dto.*;
-import com.cheocharm.MapZ.diary.domain.dto.request.DeleteTempDiary;
+import com.cheocharm.MapZ.diary.domain.dto.request.DeleteTempDiaryRequest;
 import com.cheocharm.MapZ.diary.domain.dto.request.WriteDiaryImageRequest;
 import com.cheocharm.MapZ.diary.domain.dto.response.WriteDiaryImageResponse;
 import com.cheocharm.MapZ.diary.domain.respository.DiaryImageRepository;
@@ -219,8 +219,8 @@ public class DiaryService {
     }
 
     @Transactional
-    public void deleteTempDiary(DeleteTempDiary deleteTempDiary) {
-        Long diaryId = deleteTempDiary.getDiaryId();
+    public void deleteTempDiary(DeleteTempDiaryRequest deleteTempDiaryRequest) {
+        Long diaryId = deleteTempDiaryRequest.getDiaryId();
         List<String> diaryImageURLs = diaryImageRepository.findAllByDiaryId(diaryId);
 
         s3Utils.deleteDiaryImage(diaryImageURLs);

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/dto/WriteDiaryRequest.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/dto/WriteDiaryRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import javax.validation.constraints.NotNull;
 
 @Getter
-public class WriteDiaryDto {
+public class WriteDiaryRequest {
 
     @NotNull
     private String title;
@@ -14,11 +14,5 @@ public class WriteDiaryDto {
     private String content;
 
     @NotNull
-    private Long groupId;
-
-    @NotNull
-    private Double latitude;
-
-    @NotNull
-    private Double longitude;
+    private Long diaryId;
 }

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/dto/request/DeleteTempDiaryRequest.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/dto/request/DeleteTempDiaryRequest.java
@@ -1,0 +1,11 @@
+package com.cheocharm.MapZ.diary.domain.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class DeleteTempDiaryRequest {
+    @NotNull
+    private Long diaryId;
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/dto/request/WriteDiaryImageRequest.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/dto/request/WriteDiaryImageRequest.java
@@ -1,0 +1,20 @@
+package com.cheocharm.MapZ.diary.domain.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class WriteDiaryImageRequest {
+    @NotNull
+    private Long groupId;
+
+    @NotNull
+    private String address;
+
+    @NotNull
+    private Double latitude;
+
+    @NotNull
+    private Double longitude;
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/dto/response/WriteDiaryImageResponse.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/dto/response/WriteDiaryImageResponse.java
@@ -1,0 +1,13 @@
+package com.cheocharm.MapZ.diary.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class WriteDiaryImageResponse {
+    private Long diaryId;
+    private List<String> imageURLs;
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryImageRepository.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryImageRepository.java
@@ -1,0 +1,7 @@
+package com.cheocharm.MapZ.diary.domain.respository;
+
+import com.cheocharm.MapZ.diary.domain.DiaryImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryImageRepository extends JpaRepository<DiaryImageEntity, Long>, DiaryImageRepositoryCustom {
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryImageRepositoryCustom.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryImageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.cheocharm.MapZ.diary.domain.respository;
+
+import java.util.List;
+
+public interface DiaryImageRepositoryCustom {
+    List<String> findAllByDiaryId(Long diaryId);
+
+    void deleteAllByDiaryId(Long diaryId);
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryImageRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryImageRepositoryCustomImpl.java
@@ -1,0 +1,35 @@
+package com.cheocharm.MapZ.diary.domain.respository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.cheocharm.MapZ.diary.domain.QDiaryImageEntity.diaryImageEntity;
+
+@RequiredArgsConstructor
+public class DiaryImageRepositoryCustomImpl implements DiaryImageRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public List<String> findAllByDiaryId(Long diaryId) {
+        return queryFactory
+                .select(diaryImageEntity.diaryImageUrl)
+                .from(diaryImageEntity)
+                .where(diaryIdEq(diaryId))
+                .fetch();
+    }
+
+    @Override
+    public void deleteAllByDiaryId(Long diaryId) {
+        queryFactory
+                .delete(diaryImageEntity)
+                .where(diaryIdEq(diaryId))
+                .execute();
+    }
+
+    private BooleanExpression diaryIdEq(Long diaryId) {
+        return diaryImageEntity.diaryEntity.id.eq(diaryId);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryLikeRepositoryCustomImpl.java
@@ -50,7 +50,7 @@ public class DiaryLikeRepositoryCustomImpl implements DiaryLikeRepositoryCustom{
                 .from(diaryLikeEntity)
                 .innerJoin(diaryLikeEntity.diaryEntity, diaryEntity)
                 .innerJoin(diaryEntity.groupEntity, groupEntity)
-                .leftJoin(diaryEntity.commentEntityList, commentEntity)
+                .leftJoin(diaryEntity.commentEntities, commentEntity)
                 .where(userIdEq(userId))
                 .where(diaryEntity.id.lt(cursorId))
                 .groupBy(diaryEntity.id);

--- a/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustomImpl.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/domain/respository/DiaryRepositoryCustomImpl.java
@@ -45,7 +45,7 @@ public class DiaryRepositoryCustomImpl implements DiaryRepositoryCustom {
                 ))
                 .from(diaryEntity)
                 .innerJoin(diaryEntity.groupEntity, groupEntity)
-                .leftJoin(diaryEntity.commentEntityList, commentEntity)
+                .leftJoin(diaryEntity.commentEntities, commentEntity)
                 .where(userIdEq(userId))
                 .where(diaryEntity.id.lt(cursorId))
                 .groupBy(diaryEntity.id);


### PR DESCRIPTION
처음으로 1차 요청을 통해 diary 데이터를 생성하고, 이미지를 업로드한 후 Response로 diaryId, ImageURL을 보냅니다.
2차요청을 통해 유저가 작성한 내용들을 요청받아 diary 데이터를 업데이트합니다.

이때 유저가 뒤로가거나, 예기치 못한 상황이 발생했을때 사용하던 diaryId에 해당하는 데이터들을 삭제합니다.