### PR TITLE
fix: Throwable을 넘기지 않는 문제

### DIFF
--- a/src/main/java/com/cheocharm/MapZ/common/exception/CustomException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/CustomException.java
@@ -5,13 +5,21 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private HttpStatus statusCode;
-    private String customCode;
-    private String message;
+    private final HttpStatus statusCode;
+    private final String customCode;
+    private final String message;
+    private Throwable cause;
 
     public CustomException(ExceptionDetails exceptionDetails) {
         this.statusCode = exceptionDetails.getStatusCode();
         this.customCode = exceptionDetails.getCustomCode();
         this.message = exceptionDetails.getMessage();
+    }
+
+    public CustomException(ExceptionDetails exceptionDetails, Throwable cause) {
+        this.statusCode = exceptionDetails.getStatusCode();
+        this.customCode = exceptionDetails.getCustomCode();
+        this.message = exceptionDetails.getMessage();
+        this.cause = cause;
     }
 }

--- a/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/ExceptionDetails.java
@@ -11,6 +11,9 @@ public enum ExceptionDetails {
     NOT_FOUND_API(HttpStatus.NOT_FOUND, "0001", "존재하지 않는 API입니다. 요청 경로를 확인해주세요."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "0002", "서버 에러입니다. 서버측에 문의주세요. 메시지는: "),
     FAIL_CONVERT_TO_JSON(HttpStatus.INTERNAL_SERVER_ERROR, "0003", "JSON으로 변환하는 도중 오류가 발생하였습니다."),
+    FAIL_JSON_PROCESS(HttpStatus.INTERNAL_SERVER_ERROR, "0004", "JSON에서 클래스로 변환하는 도중 오류가 발생했습니다."),
+    FAIL_PARSE(HttpStatus.INTERNAL_SERVER_ERROR, "0005", "파싱에 실패했습니다."),
+    INPUTSTREAM_IO(HttpStatus.INTERNAL_SERVER_ERROR, "0006", "입출력 예외입니다"),
 
     // S3 에러
     FAIL_CONVERT_TO_FILE(HttpStatus.BAD_REQUEST, "1001", "이미지를 파일로 변경하는데 실패하였습니다."),
@@ -49,4 +52,4 @@ public enum ExceptionDetails {
     private HttpStatus statusCode;
     private String customCode;
     private String message;
-    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,10 @@ package com.cheocharm.MapZ.common.exception;
 
 import com.cheocharm.MapZ.common.CommonResponse;
 import com.cheocharm.MapZ.common.exception.jwt.JwtExpiredException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -10,42 +13,60 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import javax.validation.ConstraintViolationException;
+import java.util.Objects;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(CustomException.class)
     protected CommonResponse<?> handleCustomException(CustomException ex) {
+        if (Objects.nonNull(ex.getCause())) {
+            logger.error("error message => {}", ex.getCause().toString());
+        }
         return CommonResponse.fail(ex.getStatusCode(), ex.getCustomCode(), ex.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(NoHandlerFoundException.class)
     protected CommonResponse<?> handleNoHandlerFoundException() {
         ExceptionDetails exceptionDetails = ExceptionDetails.NOT_FOUND_API;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected CommonResponse<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         ExceptionDetails exceptionDetails = ExceptionDetails.INVALID_USER_INFO;
-        return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+        final ObjectError objectError = ex.getBindingResult().getAllErrors().get(0);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(objectError.getObjectName()).append("에서 발생한 문제입니다. ").append(objectError.getDefaultMessage());
+        logger.error("error message => {}", sb);
+
+        return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ConstraintViolationException.class)
     protected CommonResponse<?> handleConstraintViolationException(ConstraintViolationException ex) {
         ExceptionDetails exceptionDetails = ExceptionDetails.CONSTRAINT_VIOLATION;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), ex.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected CommonResponse<?> handleException(Exception ex) {
         ExceptionDetails exceptionDetails = ExceptionDetails.INTERNAL_SERVER_ERROR;
+        logger.error("error message => {}", ex.getCause().toString());
+
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage().concat(ex.getMessage()));
     }
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(JwtExpiredException.class)
-    protected CommonResponse<?> handleJwtExpiredException() {
+    protected CommonResponse<?> handleJwtExpiredException(JwtExpiredException ex) {
         ExceptionDetails exceptionDetails = ExceptionDetails.EXPIRED_TOKEN;
         return CommonResponse.fail(exceptionDetails.getStatusCode(), exceptionDetails.getCustomCode(), exceptionDetails.getMessage());
     }

--- a/src/main/java/com/cheocharm/MapZ/common/exception/common/FailJsonProcessException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/common/FailJsonProcessException.java
@@ -1,0 +1,10 @@
+package com.cheocharm.MapZ.common.exception.common;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class FailJsonProcessException extends CustomException {
+    public FailJsonProcessException(Throwable cause) {
+        super(ExceptionDetails.FAIL_JSON_PROCESS, cause);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/exception/common/FailParseException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/common/FailParseException.java
@@ -1,0 +1,10 @@
+package com.cheocharm.MapZ.common.exception.common;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class FailParseException extends CustomException {
+    public FailParseException(Throwable cause) {
+        super(ExceptionDetails.FAIL_PARSE, cause);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/exception/common/InputStreamIOException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/common/InputStreamIOException.java
@@ -1,0 +1,10 @@
+package com.cheocharm.MapZ.common.exception.common;
+
+import com.cheocharm.MapZ.common.exception.CustomException;
+import com.cheocharm.MapZ.common.exception.ExceptionDetails;
+
+public class InputStreamIOException extends CustomException {
+    public InputStreamIOException(Throwable cause) {
+        super(ExceptionDetails.INPUTSTREAM_IO, cause);
+    }
+}

--- a/src/main/java/com/cheocharm/MapZ/common/exception/jwt/InvalidJwtException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/jwt/InvalidJwtException.java
@@ -4,6 +4,10 @@ import com.cheocharm.MapZ.common.exception.CustomException;
 import com.cheocharm.MapZ.common.exception.ExceptionDetails;
 
 public class InvalidJwtException extends CustomException {
+    public InvalidJwtException(Throwable cause) {
+        super(ExceptionDetails.INVALID_TOKEN, cause);
+    }
+
     public InvalidJwtException() {
         super(ExceptionDetails.INVALID_TOKEN);
     }

--- a/src/main/java/com/cheocharm/MapZ/common/exception/jwt/JwtExpiredException.java
+++ b/src/main/java/com/cheocharm/MapZ/common/exception/jwt/JwtExpiredException.java
@@ -4,7 +4,7 @@ import com.cheocharm.MapZ.common.exception.CustomException;
 import com.cheocharm.MapZ.common.exception.ExceptionDetails;
 
 public class JwtExpiredException extends CustomException {
-    public JwtExpiredException() {
-        super(ExceptionDetails.EXPIRED_TOKEN);
+    public JwtExpiredException(Throwable cause) {
+        super(ExceptionDetails.EXPIRED_TOKEN, cause);
     }
 }

--- a/src/main/java/com/cheocharm/MapZ/common/jwt/JwtAuthenticationUtils.java
+++ b/src/main/java/com/cheocharm/MapZ/common/jwt/JwtAuthenticationUtils.java
@@ -41,9 +41,9 @@ public class JwtAuthenticationUtils {
 
             return true;
         } catch (SignatureException | MalformedJwtException | IllegalArgumentException | UnsupportedJwtException e) {
-            throw new InvalidJwtException();
+            throw new InvalidJwtException(e);
         } catch (ExpiredJwtException e) {
-            throw new JwtExpiredException();
+            throw new JwtExpiredException(e);
         }
     }
 

--- a/src/main/java/com/cheocharm/MapZ/common/util/S3Utils.java
+++ b/src/main/java/com/cheocharm/MapZ/common/util/S3Utils.java
@@ -3,6 +3,7 @@ package com.cheocharm.MapZ.common.util;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.cheocharm.MapZ.common.exception.common.InputStreamIOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -59,7 +60,7 @@ public class S3Utils {
 
             amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new InputStreamIOException(e);
         }
     }
 

--- a/src/main/java/com/cheocharm/MapZ/diary/application/DiaryService.java
+++ b/src/main/java/com/cheocharm/MapZ/diary/application/DiaryService.java
@@ -1,5 +1,6 @@
 package com.cheocharm.MapZ.diary.application;
 
+import com.cheocharm.MapZ.common.exception.common.FailParseException;
 import com.cheocharm.MapZ.common.exception.diary.NotFoundDiaryException;
 import com.cheocharm.MapZ.common.exception.group.NotFoundGroupException;
 import com.cheocharm.MapZ.common.exception.user.NoPermissionUserException;
@@ -128,7 +129,7 @@ public class DiaryService {
         try {
             point = (Point) new WKTReader().read(pointWKT);
         } catch (ParseException e) {
-            throw new RuntimeException(e);
+            throw new FailParseException(e);
         }
         DiaryEntity diaryEntity = diaryRepository.save(
                 DiaryEntity.builder()

--- a/src/main/java/com/cheocharm/MapZ/user/application/UserService.java
+++ b/src/main/java/com/cheocharm/MapZ/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.cheocharm.MapZ.user.application;
 
 import com.cheocharm.MapZ.agreement.AgreementEntity;
 import com.cheocharm.MapZ.agreement.repository.AgreementRepository;
+import com.cheocharm.MapZ.common.exception.common.FailJsonProcessException;
 import com.cheocharm.MapZ.common.exception.jwt.InvalidJwtException;
 import com.cheocharm.MapZ.common.exception.user.DuplicatedEmailException;
 import com.cheocharm.MapZ.common.exception.user.DuplicatedUsernameException;
@@ -270,7 +271,7 @@ public class UserService {
             }
             return idToken;
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("readvalue 에러");
+            throw new FailJsonProcessException(e);
         }
     }
 

--- a/src/main/java/com/cheocharm/MapZ/user/presentation/dto/request/MapZSignUpRequest.java
+++ b/src/main/java/com/cheocharm/MapZ/user/presentation/dto/request/MapZSignUpRequest.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.*;
 
 @Getter
 public class MapZSignUpRequest {
-    @NotNull
+    @NotNull @Email
     private String email;
 
     @NotNull @Pattern(regexp = "^(?=.*\\d)(?=.*[a-zA-Z])[0-9a-zA-Z]{8,20}",


### PR DESCRIPTION
기존에는 CheckedException이 발생하는 코드에서
RuntimeException을 상속받은 CustomException을 던지도록 변경했는데

예외 추적이 어려워서 Throwable을 필드로 추가하여 예외 추적을 쉽게 할 수 있도록 했습니다.

GlobalExceptionHandler에 몇가지 예외에 대한 ResponseStatus를 추가해주었는데,
이걸보니 CustomException에도 이를 적용하고 싶네요.근데 모든 커스텀 예외가 모여있기 때문에,
출시 완료하면 CommonResponse 이걸 사용하지 않고 ResponseEntity로 반환하도록 프론트와 천천히 수정하는게 좋을거 같습니다..